### PR TITLE
VZ-3736 Fix CVE's for build from source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /.dapper
 /.cache
-/package/bin
+**/bin
 /dist
 *.swp
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /.dapper
 /.cache
-/bin
+/package/bin
 /dist
 *.swp
 .idea

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,3 +1,3 @@
-FROM alpine
+FROM ghcr.io/oracle/oraclelinux:7-slim
 COPY bin/local-path-provisioner /usr/bin/
 CMD ["local-path-provisioner"]


### PR DESCRIPTION
This introduces oraclelinux as the OS for the fork.